### PR TITLE
Adjust to new UDN API and rules

### DIFF
--- a/manifests/ns-isolation/01-namespace-isolation-l2-persistent.yaml
+++ b/manifests/ns-isolation/01-namespace-isolation-l2-persistent.yaml
@@ -1,3 +1,10 @@
+ ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test12
+  labels:
+    k8s.ovn.org/primary-user-defined-network: ""
 ---
 apiVersion: k8s.ovn.org/v1
 kind: UserDefinedNetwork
@@ -10,5 +17,6 @@ spec:
     role: Primary
     subnets:
       - 203.203.0.0/16
-    ipamLifecycle: Persistent
+    ipam:
+      lifecycle: Persistent
 

--- a/manifests/ns-isolation/03-namespace-isolation-another-ns-l2-persistent.yaml
+++ b/manifests/ns-isolation/03-namespace-isolation-another-ns-l2-persistent.yaml
@@ -1,3 +1,10 @@
+ ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: another-namespace
+  labels:
+    k8s.ovn.org/primary-user-defined-network: ""
 ---
 apiVersion: k8s.ovn.org/v1
 kind: UserDefinedNetwork
@@ -10,5 +17,6 @@ spec:
     role: Primary
     subnets:
       - 192.168.0.0/16
-    ipamLifecycle: Persistent
+    ipam:
+      lifecycle: Persistent
 


### PR DESCRIPTION
The API was changed - there's now an IPAM block where the `lifecycle` attribute is set, plus, the namespace where the UDN will be created must be labeled w/ the `k8s.ovn.org/primary-user-defined-network` key.